### PR TITLE
Fix dialer name ordering options not being respected on first load.

### DIFF
--- a/src/com/android/contacts/common/list/ContactEntryListFragment.java
+++ b/src/com/android/contacts/common/list/ContactEntryListFragment.java
@@ -150,11 +150,15 @@ public abstract class ContactEntryListFragment<T extends ContactEntryListAdapter
     private Context mContext;
 
     private LoaderManager mLoaderManager;
+    private boolean mIgnoreSimStateChange;
 
     private BroadcastReceiver mSIMStateReceiver = new BroadcastReceiver() {
         @Override
-        public void onReceive(Context arg0, Intent arg1) {
-            reloadData();
+        public void onReceive(Context context, Intent intent) {
+            if (!mIgnoreSimStateChange) {
+                reloadData();
+            }
+            mIgnoreSimStateChange = false;
         }
     };
 
@@ -265,13 +269,6 @@ public abstract class ContactEntryListFragment<T extends ContactEntryListAdapter
         mAdapter = createListAdapter();
         mContactsPrefs = new ContactsPreferences(mContext);
         restoreSavedState(savedState);
-
-        IntentFilter filter = new IntentFilter();
-        filter.addAction(Intent.ACTION_AIRPLANE_MODE_CHANGED);
-        filter.addAction(TelephonyIntents.ACTION_SIM_STATE_CHANGED);
-        if (mContext != null) {
-            mContext.registerReceiver(mSIMStateReceiver, filter);
-        }
     }
 
     public void restoreSavedState(Bundle savedState) {
@@ -308,6 +305,13 @@ public abstract class ContactEntryListFragment<T extends ContactEntryListAdapter
 
         mDirectoryListStatus = STATUS_NOT_LOADED;
         mLoadPriorityDirectoriesOnly = true;
+
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(Intent.ACTION_AIRPLANE_MODE_CHANGED);
+        filter.addAction(TelephonyIntents.ACTION_SIM_STATE_CHANGED);
+        // Make sure to not trigger a full reload by the sticky SIM state change
+        // broadcast delivery on registration
+        mIgnoreSimStateChange = mContext.registerReceiver(mSIMStateReceiver, filter) != null;
 
         startLoading();
     }
@@ -476,14 +480,7 @@ public abstract class ContactEntryListFragment<T extends ContactEntryListAdapter
         super.onStop();
         mContactsPrefs.unregisterChangeListener();
         mAdapter.clearPartitions();
-    }
-
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-        if (mContext != null) {
-            mContext.unregisterReceiver(mSIMStateReceiver);
-        }
+        mContext.unregisterReceiver(mSIMStateReceiver);
     }
 
     protected void reloadData() {


### PR DESCRIPTION
Do this by making sure the contact loader isn't started before
preferences are loaded.

Change-Id: Iaa589b65ccf5757e25b7d4f1beb9a7496797280c